### PR TITLE
Fixed the Devise:Missing Warden rspec error

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,10 @@
 class GamesController < ApplicationController
  before_action :authenticate_user!, only: [:new, :create, :show]
+
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end
+
     def new
         @game = Game.new
     end


### PR DESCRIPTION
Fixed the Devise:Missing Warden rspec error by adding Rspec configure to the games_controller.
With this fix there are 6 examples, 2 failures and 3 pending when running rspec